### PR TITLE
Feature/prop details

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -32,6 +32,10 @@ $nav-height: 4.5rem;
   background-color: #283593;
   color: white;
 
+  * {
+    margin: 0;
+  }
+
   h1 {
     font-size: 1.8rem;
   }
@@ -71,8 +75,5 @@ $nav-height: 4.5rem;
 }
 
 .MainContent {
-  width: fit-content;
-  max-width: 700px;
-  margin: 0 auto;
   padding: 24px;
 }

--- a/src/pages/AboutPage/AboutPage.jsx
+++ b/src/pages/AboutPage/AboutPage.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import styles from './AboutPage.module.scss';
 
 const AboutPage = () => (
-  <>
+  <div className={styles.AboutPage}>
     <h2>About this Playground</h2>
 
     <h3>First of all</h3>
@@ -66,7 +67,7 @@ const AboutPage = () => (
       </a>{' '}
       live-streaming series.
     </p>
-  </>
+  </div>
 );
 
 export default AboutPage;

--- a/src/pages/AboutPage/AboutPage.module.scss
+++ b/src/pages/AboutPage/AboutPage.module.scss
@@ -1,0 +1,4 @@
+.AboutPage {
+  max-width: 700px;
+  margin: 0 auto;
+}

--- a/src/pages/ComponentPage/ComponentPage.jsx
+++ b/src/pages/ComponentPage/ComponentPage.jsx
@@ -8,6 +8,7 @@ const buildComponentProps = (props) => {
   return Object.entries(props).map(([propTypeName, propTypes]) => {
     const name = propTypeName;
     const type = propTypes.type;
+    const isRequired = propTypes.isRequired;
 
     let value;
     if (type === 'boolean') {
@@ -17,12 +18,18 @@ const buildComponentProps = (props) => {
     } else if (type === 'json') {
       value = '{}';
     } else if (type === 'arrayOf') {
-      value = '[]';
+      value = `[${
+        propTypes.shape
+          ? `{${Object.entries(propTypes.shape)
+              .map(([attribute]) => `"${attribute}": ""`)
+              .join(',')}}`
+          : ''
+      }]`;
     } else {
       value = '';
     }
 
-    return { name, type, value };
+    return { name, type, value, isRequired };
   });
 };
 
@@ -100,7 +107,9 @@ const ComponentPage = () => {
                 <option value="func">Function</option>
                 <option value="arrayOf">Array</option>
               </select>
-              {prop.type === 'json' || prop.type === 'func' ? (
+              {prop.type === 'json' ||
+              prop.type === 'func' ||
+              prop.type === 'arrayOf' ? (
                 <textarea
                   value={prop.value}
                   onChange={(e) => {

--- a/src/pages/ComponentPage/ComponentPage.jsx
+++ b/src/pages/ComponentPage/ComponentPage.jsx
@@ -5,32 +5,40 @@ import '@amb-codes-crafts/a11y-components/dist/index.css';
 import styles from './ComponentPage.module.scss';
 
 const buildComponentProps = (props) => {
-  return Object.entries(props).map(([propTypeName, propTypes]) => {
-    const name = propTypeName;
-    const type = propTypes.type;
-    const isRequired = propTypes.isRequired;
+  return Object.entries(props)
+    .map(([propTypeName, propTypes]) => {
+      const name = propTypeName;
+      const type = propTypes.type;
+      const isRequired = propTypes.isRequired;
 
-    let value;
-    if (type === 'boolean') {
-      value = true;
-    } else if (type === 'func') {
-      value = '() => {}';
-    } else if (type === 'json') {
-      value = '{}';
-    } else if (type === 'arrayOf') {
-      value = `[${
-        propTypes.shape
-          ? `{${Object.entries(propTypes.shape)
-              .map(([attribute]) => `"${attribute}": ""`)
-              .join(',')}}`
-          : ''
-      }]`;
-    } else {
-      value = '';
-    }
+      let value;
+      if (type === 'boolean') {
+        value = true;
+      } else if (type === 'func') {
+        value = '() => {}';
+      } else if (type === 'json') {
+        value = '{}';
+      } else if (type === 'arrayOf') {
+        value = `[${
+          propTypes.shape
+            ? `{${Object.entries(propTypes.shape)
+                .map(([attribute]) => `"${attribute}": ""`)
+                .join(',')}}`
+            : ''
+        }]`;
+      } else {
+        value = '';
+      }
 
-    return { name, type, value, isRequired };
-  });
+      return { name, type, value, isRequired };
+    })
+    .sort((a, b) => {
+      if (a.isRequired && !b.isRequired) {
+        return -1;
+      }
+
+      return 1;
+    });
 };
 
 const getComponentProps = (props) => {

--- a/src/pages/ComponentPage/ComponentPage.jsx
+++ b/src/pages/ComponentPage/ComponentPage.jsx
@@ -140,6 +140,7 @@ const ComponentPage = () => {
                 title={`Remove "${prop.name}" prop`}
                 aria-label={`Remove ${prop.name} property`}
                 className={styles.DeleteButton}
+                disabled={prop.isRequired}
                 onClick={() => {
                   componentProps.splice(index, 1);
                   setComponentProps([...componentProps]);

--- a/src/pages/ComponentPage/ComponentPage.module.scss
+++ b/src/pages/ComponentPage/ComponentPage.module.scss
@@ -17,6 +17,7 @@
 
       h3 {
         text-align: left;
+        margin-top: 0;
         margin-bottom: 12px;
       }
     }
@@ -69,12 +70,16 @@
           border: 1px solid black;
           border-radius: 14px;
 
-          &:hover {
+          &:hover:not(:disabled) {
             cursor: pointer;
             background-color: white;
             border-width: 2px;
             line-height: 26px;
             font-weight: bold;
+          }
+
+          &:hover:disabled {
+            cursor: not-allowed;
           }
         }
 

--- a/src/pages/HomePage/HomePage.module.scss
+++ b/src/pages/HomePage/HomePage.module.scss
@@ -3,6 +3,8 @@ $top-bottom-padding: $font-size * 0.2;
 $left-right-padding: $font-size * 0.6;
 
 .HomePage {
+  max-width: 700px;
+  margin: 0 auto;
   text-align: center;
 
   h2 {


### PR DESCRIPTION
# Overview

It's currently impossible for someone to know what the shape of `arrayOf` properties look like if they haven't looked into the code for a component. This PR mainly fixes that by making the preloaded property show the attributes for its objects.

This PR also sorts properties so that required ones show before optional ones, and it also does not allow required properties to be removed. There are a few styling tweaks too.

# Relevant issues

- closes #1 Show prop details at the top of the component page so people know what they're working with
- closes #2 Don't allow required props to be removed from the component page
- closes #4 Show required props before optional ones in component page

# Testing

- [x] Open the Netlify deploy preview after the checks finish
- [x] View the Listbox component
- [x] It should look like this:

![Screen Shot 2020-10-21 at 10 26 15 AM](https://user-images.githubusercontent.com/43934258/96733799-dcbfc480-1387-11eb-8d4d-dd773b89b039.png)

- [x] You should not be able to remove the `label` or `options` props
- [x] Remove the `value` prop
- [x] Fill in the `id` and `label` in the first option
- [x] Add a second, unique option
- [x] Paste this for the `onChange`:

```
(selectedId) => {
  alert(selectedId + ' was selected');
}
```

- [x] Choose the second option from the rendered component
- [x] You should see an alert that matches the `id` you gave for the option